### PR TITLE
Add Duke Nukem MP Enhanced Edition

### DIFF
--- a/ULWGL-database.csv
+++ b/ULWGL-database.csv
@@ -582,3 +582,4 @@ Disaster Report 4: Summer Memories,egs,6684d2b2f9764f5c9c1c59de162c8a8e,ulwgl-10
 The Legend of Heroes: Trails in the Sky,gog,1207665083,ulwgl-251150,,
 The Legend of Heroes: Trails in the Sky SC,gog,14448264193,ulwgl-251290,,
 The Legend of Heroes: Trails in the Sky the 3rd,gog,1797747105,ulwgl-436670,,
+Duke Nukem: Manhattan Project - Enhanced Edition,zoomplatform,e87704e6-e558-4605-8981-89a7914742e0,ulwgl-240200,,Has specific fixes for the EE launcher and wrapper

--- a/ULWGL-database.csv
+++ b/ULWGL-database.csv
@@ -582,4 +582,4 @@ Disaster Report 4: Summer Memories,egs,6684d2b2f9764f5c9c1c59de162c8a8e,ulwgl-10
 The Legend of Heroes: Trails in the Sky,gog,1207665083,ulwgl-251150,,
 The Legend of Heroes: Trails in the Sky SC,gog,14448264193,ulwgl-251290,,
 The Legend of Heroes: Trails in the Sky the 3rd,gog,1797747105,ulwgl-436670,,
-Duke Nukem: Manhattan Project - Enhanced Edition,zoomplatform,e87704e6-e558-4605-8981-89a7914742e0,ulwgl-240200,,Has specific fixes for the EE launcher and wrapper
+Duke Nukem: Manhattan Project,zoomplatform,e87704e6-e558-4605-8981-89a7914742e0,ulwgl-240200,,Has specific fixes for the launcher and wrapper (Enhanced Edition)


### PR DESCRIPTION
This is separate from Steam appid is because it works differently from the Steam/GOG builds. Relevant changes are that launcher was rebuilt and it ships with a wrapper for when users choose the DX renderer.

In theory, the non EE version of the game _should_ work fine without a fix but we can't test the other builds due to them not being accessible anymore.