### PR TITLE
gog: Add Soldier of Fortune II

### DIFF
--- a/ULWGL-database.csv
+++ b/ULWGL-database.csv
@@ -582,3 +582,4 @@ Disaster Report 4: Summer Memories,egs,6684d2b2f9764f5c9c1c59de162c8a8e,ulwgl-10
 The Legend of Heroes: Trails in the Sky,gog,1207665083,ulwgl-251150,,
 The Legend of Heroes: Trails in the Sky SC,gog,14448264193,ulwgl-251290,,
 The Legend of Heroes: Trails in the Sky the 3rd,gog,1797747105,ulwgl-436670,,
+Soldier of Fortune II: Double Helix - Gold Edition,gog,1228964594,ulwgl-1228964594,,


### PR DESCRIPTION
Adds the GOG version of SoF II to the database.

https://github.com/Open-Wine-Components/ULWGL-protonfixes/pull/18